### PR TITLE
apply Carpentries Incubator template

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,11 +7,12 @@
 # dc: Data Carpentry
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
-carpentry: "dc"
+carpentry: "incubator"
 
 # Overall title for pages.
 title: "Project Organization and Management for Metagenomics"
 
+life_cycle: "beta"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).
@@ -61,7 +62,7 @@ collections:
   extras:
     output: true
     permalink: /:path/index.html
-    
+
 # Set the default layout for things in the episodes collection.
 defaults:
   - values:
@@ -79,7 +80,7 @@ defaults:
     values:
       root: ..
       layout: page
- 
+
 # Files and directories that are not to be copied.
 exclude:
   - Makefile


### PR DESCRIPTION
This adjusts the lesson styling to use the Incubator template via [the remote theme](https://github.com/carpentries/carpentries-theme), and sets the life cycle stage to "beta"